### PR TITLE
Remove python-pip from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ secure-smtplib
 pydig
 email-to
 dkimpy
-python-apt
 python-whois


### PR DESCRIPTION
Having python-pip in the requirements makes running this package in docker fail.